### PR TITLE
Add Terraform CI for parameter tests

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -1,0 +1,26 @@
+name: Terraform
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  terraform:
+    runs-on: ubuntu-latest
+    env:
+      AWS_ACCESS_KEY_ID: test
+      AWS_SECRET_ACCESS_KEY: test
+      AWS_REGION: us-east-1
+      AWS_EC2_METADATA_DISABLED: true
+    steps:
+      - uses: actions/checkout@v4
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: "1.7.5"
+      - run: terraform fmt -check -recursive
+      - run: terraform init -backend=false
+      - run: terraform validate
+      - run: scripts/tf-test.sh

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Auto-generated technical documentation is created using [`terraform-docs`](https
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.15 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.0, < 6.0 |
 
 ## Providers
 
@@ -98,9 +98,6 @@ No modules.
 | [aws_ssm_parameter.parameter_map](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
 | [aws_ssm_parameter.parameter_map_ignore](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
 | [random_id.parameter-random](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id) | resource |
-| [aws_availability_zones.az](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/availability_zones) | data source |
-| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
-| [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
 
 ## Inputs
 

--- a/data-sources.tf
+++ b/data-sources.tf
@@ -1,7 +1,0 @@
-# This file is for data sources that may be required for the module to run.
-
-data "aws_caller_identity" "current" {}
-data "aws_region" "current" {}
-data "aws_availability_zones" "az" {
-  state = "available"
-}

--- a/examples/basic-usage/example.tf
+++ b/examples/basic-usage/example.tf
@@ -9,7 +9,7 @@ provider "aws" {
 
 module "parameter" {
   source         = "so1omon563/ssm-parameter/aws"
-  version = "3.0.0" # Replace with appropriate version
+  version        = "3.0.0" # Replace with appropriate version
   ignore_changes = false
 
   name           = "example-parameter"

--- a/locals.tf
+++ b/locals.tf
@@ -1,8 +1,7 @@
 # This file is for local values that may be required for the module to run.
 
 locals {
-  account_id = data.aws_caller_identity.current.account_id
-  tags       = var.tags
+  tags = var.tags
   # Setting these 3 values to avoid mixing count and for_each. It also helps better name the outputs. The value is irrelavent. We only care about the key.
   parameter_ignore = var.ignore_changes == true && var.parameter_map == null ? { "parameter" = "ignore" } : {}
   parameter        = var.ignore_changes == false && var.parameter_map == null ? { "parameter" = "noignore" } : {}

--- a/main.tf
+++ b/main.tf
@@ -6,7 +6,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.0"
+      version = ">= 4.0, < 6.0"
     }
   }
 }

--- a/test/basic-usage/basic-usage.tf
+++ b/test/basic-usage/basic-usage.tf
@@ -1,4 +1,7 @@
 provider "aws" {
+  skip_credentials_validation = true
+  skip_requesting_account_id  = true
+
   default_tags {
     tags = {
       environment = "dev"


### PR DESCRIPTION
## Summary
- add pull-request Terraform CI for the existing native test fixture
- remove unused AWS data sources so plan-only tests do not call live AWS APIs
- keep AWS provider resolution on the current v4/v5 line pending a separate provider-v6 review

## Verification
- terraform fmt -check -recursive
- terraform init -backend=false
- terraform validate
- scripts/tf-test.sh